### PR TITLE
UDA/MSCP updates for QBus systems

### DIFF
--- a/10.02_devices/2_src/mscp_drive.hpp
+++ b/10.02_devices/2_src/mscp_drive.hpp
@@ -17,91 +17,98 @@
 //
 // Implements the backing store for MSCP disk images
 //
-class mscp_drive_c: public storagedrive_c {
+class mscp_drive_c: public storagedrive_c 
+{
 public:
-	mscp_drive_c(storagecontroller_c *controller, uint32_t driveNumber);
-	~mscp_drive_c(void);
+    mscp_drive_c(storagecontroller_c *controller, uint32_t driveNumber);
+    ~mscp_drive_c(void);
 
-	bool on_param_changed(parameter_c *param) override;
+    bool on_param_changed(parameter_c *param) override;
 
-	uint32_t GetBlockSize(void);
-	uint32_t GetBlockCount(void);
-	uint32_t GetRCTBlockCount(void);
-	uint32_t GetMediaID(void);
-	uint32_t GetDeviceNumber(void);
-	uint16_t GetClassModel(void);
-	uint16_t GetRCTSize(void);
-	uint8_t GetRBNs(void);
-	uint8_t GetRCTCopies(void);
+    uint32_t GetBlockSize(void);
+    uint32_t GetBlockCount(void);
+    uint32_t GetRCTBlockCount(void);
+    uint32_t GetMediaID(void);
+    uint32_t GetDeviceNumber(void);
+    uint16_t GetClassModel(void);
+    uint16_t GetRCTSize(void);
+    uint8_t GetRBNs(void);
+    uint8_t GetRCTCopies(void);
 
-	void SetOnline(void);
-	void SetOffline(void);bool IsOnline(void);bool IsAvailable(void);
+    void SetOnline(void);
+    void SetOffline(void);bool IsOnline(void);bool IsAvailable(void);
 
-	void Write(uint32_t blockNumber, size_t lengthInBytes, uint8_t* buffer);
+    void Write(uint32_t blockNumber, size_t lengthInBytes, uint8_t* buffer);
 
-	uint8_t* Read(uint32_t blockNumber, size_t lengthInBytes);
+    uint8_t* Read(uint32_t blockNumber, size_t lengthInBytes);
 
-	void WriteRCTBlock(uint32_t rctBlockNumber, uint8_t* buffer);
+    void WriteRCTBlock(uint32_t rctBlockNumber, uint8_t* buffer);
 
-	uint8_t* ReadRCTBlock(uint32_t rctBlockNumber);
-
-public:
-	void on_power_changed(signal_edge_enum aclo_edge, signal_edge_enum dclo_edge) override;
-	void on_init_changed(void) override;
+    uint8_t* ReadRCTBlock(uint32_t rctBlockNumber);
 
 public:
-	parameter_bool_c use_image_size = parameter_bool_c(this, "useimagesize", "uis", false,
-			"Determine unit size from image file instead of drive type");
+    void on_power_changed(signal_edge_enum aclo_edge, signal_edge_enum dclo_edge) override;
+    void on_init_changed(void) override;
+
+public:
+    parameter_bool_c use_image_size = parameter_bool_c(this, "useimagesize", "uis", false,
+        "Determine unit size from image file instead of drive type");
 
 private:
 
-	struct DriveInfo {
-		char TypeName[16];
-		size_t BlockCount;
-		uint32_t MediaID;
-		uint8_t Model;
-		uint16_t RCTSize;bool Removable;bool ReadOnly;
-	};
+    struct DriveInfo 
+    {
+        char TypeName[16];
+        size_t BlockCount;
+        uint32_t MediaID;
+        uint8_t Model;
+        uint16_t RCTSize;bool Removable;bool ReadOnly;
+    };
 
-	//
-	// TODO: add a lot more drive types.
-	// Does it make sense to support drive types not native to QBus/Unibus machines (SCSI types, for example?)
-	// Need to add a ClassID table entry in that eventuality...
-	// Also TODO: RCTSize parameters taken from SIMH rq source; how valid are these?
-	DriveInfo g_driveTable[21] {
-//    Name     Blocks    MediaID     Model  RCTSize  Removable  ReadOnly
-			{ "RX50", 800, 0x25658032, 7, 0, true, false }, { "RX33", 2400, 0x25658021, 10, 0,
-					true, false }, { "RD51", 21600, 0x25644033, 6, 36, false, false }, { "RD31",
-					41560, 0x2564401f, 12, 3, false, false }, { "RC25", 50902, 0x20643019, 2, 0,
-					true, false }, { "RC25F", 50902, 0x20643319, 3, 0, true, false }, { "RD52",
-					60480, 0x25644034, 8, 4, false, false }, { "RD32", 83236, 0x25641047, 15, 4,
-					false, false }, { "RD53", 138672, 0x25644035, 9, 5, false, false }, {
-					"RA80", 237212, 0x20643019, 1, 0, false, false }, { "RD54", 311200,
-					0x25644036, 13, 7, false, false }, { "RA60", 400176, 0x22a4103c, 4, 1008,
-					true, false }, { "RA70", 547041, 0x20643019, 18, 198, false, false }, {
-					"RA81", 891072, 0x25641051, 5, 2856, false, false }, { "RA82", 1216665,
-					0x25641052, 11, 3420, false, false }, { "RA71", 1367310, 0x25641047, 40,
-					1428, false, false },
-			{ "RA72", 1953300, 0x25641048, 37, 2040, false, false }, { "RA90", 2376153,
-					0x2564105a, 19, 1794, false, false }, { "RA92", 2940951, 0x2564105c, 29,
-					949, false, false }, { "RA73", 3920490, 0x25641049, 47, 198, false, false },
-			{ "", 0, 0, 0, 0, false, false } };
+    //
+    // TODO: add a lot more drive types.
+    // Does it make sense to support drive types not native to QBus/Unibus machines (SCSI types, for example?)
+    // Need to add a ClassID table entry in that eventuality...
+    // Also TODO: RCTSize parameters taken from SIMH rq source; how valid are these?
+    DriveInfo g_driveTable[21] {
+        //    Name     Blocks    MediaID     Model  RCTSize  Removable  ReadOnly
+	   { "RX50",   800,      0x25658032, 7,     0,       true,      false }, 
+           { "RX33",   2400,     0x25658021, 10,    0,       true,      false },
+           { "RD51",   21600,    0x25644033, 6,     36,      false,     false }, 
+           { "RD31",   41560,    0x2564401f, 12,    3,       false,     false }, 
+           { "RC25",   50902,    0x20643019, 2,     0,       true,      false },
+           { "RC25F",  50902,    0x20643319, 3,     0,       true,      false }, 
+           { "RD52",   60480,    0x25644034, 8,     4,       false,     false }, 
+           { "RD32",   83236,    0x25641047, 15,    4,       false,     false },
+           { "RD53",   138672,   0x25644035, 9,     5,       false,     false },
+           { "RA80",   237212,   0x20643019, 1,     0,       false,     false }, 
+           { "RD54",   311200,   0x25644036, 13,    7,       false,     false }, 
+           { "RA60",   400176,   0x22a4103c, 4,     1008,    true,      false },
+           { "RA70",   547041,   0x20643019, 18,    198,     false,     false }, 
+           { "RA81",   891072,   0x25641051, 5,     2856,    false,     false }, 
+           { "RA82",   1216665,  0x25641052, 11,    3420,    false,     false }, 
+           { "RA71",   1367310,  0x25641047, 40,    1428,    false,     false },
+           { "RA72",   1953300,  0x25641048, 37,    2040,    false,     false }, 
+           { "RA90",   2376153,  0x2564105a, 19,    1794,    false,     false }, 
+           { "RA92",   2940951,  0x2564105c, 29,    949,     false,     false },
+           { "RA73",   3920490,  0x25641049, 47,    198,     false,     false },
+           { "", 0, 0, 0, 0, false, false } };
 
-	bool SetDriveType(const char* typeName);
-	void UpdateCapacity(void);
-	void UpdateMetadata(void);
-	DriveInfo _driveInfo;bool _online;
-	uint32_t _unitDeviceNumber;
-	uint16_t _unitClassModel;
-	bool _useImageSize;
+    bool SetDriveType(const char* typeName);
+    void UpdateCapacity(void);
+    void UpdateMetadata(void);
+    DriveInfo _driveInfo;bool _online;
+    uint32_t _unitDeviceNumber;
+    uint16_t _unitClassModel;
+    bool _useImageSize;
 
-	//
-	// RCT ("Replacement and Caching Table") data:
-	// The size of this area varies depending on the drive.  This is
-	// provided only to appease software that expects the RCT to exist --
-	// since there will never be any bad sectors in our disk images
-	// there is no other purpose.
-	// This data is not persisted to disk as it is unnecessary.
-	//
-	unique_ptr<uint8_t> _rctData;
+    //
+    // RCT ("Replacement and Caching Table") data:
+    // The size of this area varies depending on the drive.  This is
+    // provided only to appease software that expects the RCT to exist --
+    // since there will never be any bad sectors in our disk images
+    // there is no other purpose.
+    // This data is not persisted to disk as it is unnecessary.
+    //
+    unique_ptr<uint8_t> _rctData;
 };

--- a/10.02_devices/2_src/uda.hpp
+++ b/10.02_devices/2_src/uda.hpp
@@ -21,13 +21,18 @@
 #define DRIVE_COUNT 8
 
 // The control/microcode version info returned by SA in the fourth intialization step.
-// This indicates a UDA50 controller, which makes RSTS happy.
-#define UDA50_ID 0x4063
+#define UDA50_ID 0x0063
+#define RQDX3_ID 0x0133
 
 // The maximum message length we can handle.  This is provided as a sanity check
-// to prvent parsing clearly invalid commands.
+// to prevent parsing clearly invalid commands.
 #define MAX_MESSAGE_LENGTH 0x1000
 
+#define STEP1    0x0800
+#define STEP2    0x1000
+#define STEP3    0x2000
+#define STEP4    0x4000
+#define STEP1_22_BIT 0x200
 
 // TODO: this currently assumes a little-endian machine!
 #pragma pack(push,1)
@@ -74,12 +79,15 @@ public:
     void on_init_changed(void) override;
 
     void on_drive_status_changed(storagedrive_c *drive) override;
-
 	
     // As every storage controller UDA has one INTR and DMA
     dma_request_c dma_request = dma_request_c(this) ; // operated by qunibusadapter
     intr_request_c intr_request = intr_request_c(this) ;
-	
+
+    // Configuration parameter for 22-bit DMA
+    parameter_bool_c twenty_two_bit_DMA = parameter_bool_c(this, "22_bit_dma", "dma22",
+        false, "Enable 22-bit DMA"); 
+   	
 public:
 
     //
@@ -109,6 +117,13 @@ private:
     uint32_t GetCommandDescriptorAddress(size_t index);
     uint32_t GetResponseDescriptorAddress(size_t index);
 
+    enum ControllerType {
+        UDA50 = 0,
+        RQDX3 = 1,
+    } _controllerType;
+
+    bool _22bitDMA;
+   
 public:
     bool DMAWriteWord(uint32_t address, uint16_t word);
     uint16_t DMAReadWord(uint32_t address, bool& success);


### PR DESCRIPTION
Added 22-bit DMA flag to UDA sync handshake, as well as options to configure the controller

to support it, and to identify as either a UDA50 or an RQDX3 controller.

Minor code cleanup.