### PR TITLE
Fix MSCP crash for older VMS

### DIFF
--- a/10.02_devices/2_src/mscp_server.cpp
+++ b/10.02_devices/2_src/mscp_server.cpp
@@ -629,12 +629,13 @@ mscp_server::GetUnitStatus(
     // This has nothing whatsoever to do with what's going on here but it makes me snicker
     // every time I read it so I'm including it.
     // Let's relay some information about our data-tesseract:
-    // Since our underlying storage is an image file on flash memory, we don't need to be concerned
-    // about seek times, so the below is appropriate:
-    //
-    params->TrackSize = 1;  
-    params->GroupSize = 1;  
-    params->CylinderSize = 1; 
+    // For older VMS, this can't be "fake", as (Track,Group,Cylinder) = (1,1,1)
+    // seems to cause an overflow somewhere. A fixed track of 16 sectors (2MB) and a cap of
+    // 2047 cylinders is necessary & sufficient.
+    params->TrackSize = 16;
+    params->GroupSize = 1;
+    params->CylinderSize = ((drive->GetBlockCount() / 4096) + 1),
+    params->CylinderSize = std::min(params->CylinderSize, (uint16_t) 2047);
 
     params->RCTSize = drive->GetRCTSize();
     params->RBNs = drive->GetRBNs();


### PR DESCRIPTION
(Track,Group,Cylinder) = (1,1,1) causes some kind of overflow in older VMS (e.g. 5.5-2) on startup.

Using a fixed track size of 16 and limiting cylinders to 2047 resolves the issue. MSCP disks being limted to a max size of 4GB is not a problem; this is larger than the biggest DEC drive of the era, the 1.5GB RA92.