### PR TITLE
Fix MSCP under older VMS

### DIFF
--- a/10.02_devices/2_src/mscp_drive.cpp
+++ b/10.02_devices/2_src/mscp_drive.cpp
@@ -124,6 +124,31 @@ uint32_t mscp_drive_c::GetDeviceNumber()
 }
 
 //
+// GetSectsPerTrack():
+//  Returns the sectors per track for this drive.
+//
+uint16_t mscp_drive_c::GetSectsPerTrack()
+{
+    return _driveInfo.SectsPerTrack;
+}
+//
+// GetTracksPerGroup():
+//  Returns the tracks per group for this drive.
+//
+uint16_t mscp_drive_c::GetTracksPerGroup()
+{
+    return _driveInfo.TracksPerGroup;
+}
+//
+// GetGroupsPerCylinder():
+//  Returns the groups per cylinder for this drive.
+//
+uint16_t mscp_drive_c::GetGroupsPerCylinder()
+{
+    return _driveInfo.GroupsPerCylinder;
+}
+
+//
 // GetClassModel():
 //  Returns the class and model information for this drive.
 //

--- a/10.02_devices/2_src/mscp_drive.hpp
+++ b/10.02_devices/2_src/mscp_drive.hpp
@@ -32,6 +32,9 @@ public:
     uint32_t GetDeviceNumber(void);
     uint16_t GetClassModel(void);
     uint16_t GetRCTSize(void);
+    uint16_t GetSectsPerTrack(void);
+    uint16_t GetTracksPerGroup(void);
+    uint16_t GetGroupsPerCylinder(void);
     uint8_t GetRBNs(void);
     uint8_t GetRCTCopies(void);
 
@@ -58,12 +61,17 @@ private:
 
     struct DriveInfo 
     {
-	    enum drive_type_e Type ;
+        enum drive_type_e Type;
         char TypeName[16];
         size_t BlockCount;
+        uint16_t SectsPerTrack;
+        uint16_t TracksPerGroup;
+        uint16_t GroupsPerCylinder;
         uint32_t MediaID;
         uint8_t Model;
-        uint16_t RCTSize;bool Removable;bool ReadOnly;
+        uint16_t RCTSize;
+        bool Removable;
+        bool ReadOnly;
     };
 
     //
@@ -72,33 +80,34 @@ private:
     // Need to add a ClassID table entry in that eventuality...
     // Also TODO: RCTSize parameters taken from SIMH rq source; how valid are these?
     DriveInfo g_driveTable[21] {
-        //    Name     Blocks    MediaID     Model  RCTSize  Removable  ReadOnly
-	   { drive_type_e::RX50, "RX50",   800,      0x25658032, 7,     0,       true,      false }, 
-           { drive_type_e::RX33, "RX33",   2400,     0x25658021, 10,    0,       true,      false },
-           { drive_type_e::RD51, "RD51",   21600,    0x25644033, 6,     36,      false,     false }, 
-           { drive_type_e::RD31, "RD31",   41560,    0x2564401f, 12,    3,       false,     false }, 
-           { drive_type_e::RC25, "RC25",   50902,    0x20643019, 2,     0,       true,      false },
-           { drive_type_e::RC25F,"RC25F",  50902,    0x20643319, 3,     0,       true,      false }, 
-           { drive_type_e::RD52, "RD52",   60480,    0x25644034, 8,     4,       false,     false }, 
-           { drive_type_e::RD32, "RD32",   83236,    0x25641047, 15,    4,       false,     false },
-           { drive_type_e::RD53, "RD53",   138672,   0x25644035, 9,     5,       false,     false },
-           { drive_type_e::RA80, "RA80",   237212,   0x20643019, 1,     0,       false,     false }, 
-           { drive_type_e::RD54, "RD54",   311200,   0x25644036, 13,    7,       false,     false }, 
-           { drive_type_e::RA60, "RA60",   400176,   0x22a4103c, 4,     1008,    true,      false },
-           { drive_type_e::RA70, "RA70",   547041,   0x20643019, 18,    198,     false,     false }, 
-           { drive_type_e::RA81, "RA81",   891072,   0x25641051, 5,     2856,    false,     false }, 
-           { drive_type_e::RA82, "RA82",   1216665,  0x25641052, 11,    3420,    false,     false }, 
-           { drive_type_e::RA71, "RA71",   1367310,  0x25641047, 40,    1428,    false,     false },
-           { drive_type_e::RA72, "RA72",   1953300,  0x25641048, 37,    2040,    false,     false }, 
-           { drive_type_e::RA90, "RA90",   2376153,  0x2564105a, 19,    1794,    false,     false }, 
-           { drive_type_e::RA92, "RA92",   2940951,  0x2564105c, 29,    949,     false,     false },
-           { drive_type_e::RA73, "RA73",   3920490,  0x25641049, 47,    198,     false,     false },
-           { drive_type_e::NONE, "", 0, 0, 0, 0, false, false } };
+        // Type, Name, Blocks, Sct, Tpg, Gpc, MediaID, Model, RCTSize, Removable, ReadOnly
+        { drive_type_e::RX50, "RX50",   800,      10,  5, 16, 0x25658032, 7,     0,       true,      false },
+        { drive_type_e::RX33, "RX33",   2400,     15,  2,  1, 0x25658021, 10,    0,       true,      false },
+        { drive_type_e::RD51, "RD51",   21600,    18,  4,  1, 0x25644033, 6,     36,      false,     false },
+        { drive_type_e::RD31, "RD31",   41560,    17,  4,  1, 0x2564401f, 12,    3,       false,     false },
+        { drive_type_e::RC25, "RC25",   50902,    50,  8,  1, 0x20643019, 2,     0,       true,      false },
+        { drive_type_e::RC25F,"RC25F",  50902,    50,  8,  1, 0x20643319, 3,     0,       true,      false },
+        { drive_type_e::RD52, "RD52",   60480,    17,  8,  1, 0x25644034, 8,     4,       false,     false },
+        { drive_type_e::RD32, "RD32",   83236,    17,  6,  1, 0x25641047, 15,    4,       false,     false },
+        { drive_type_e::RD53, "RD53",   138672,   17,  8,  1, 0x25644035, 9,     5,       false,     false },
+        { drive_type_e::RA80, "RA80",   237212,   31, 14,  1, 0x20643019, 1,     0,       false,     false },
+        { drive_type_e::RD54, "RD54",   311200,   17, 15,  1, 0x25644036, 13,    7,       false,     false },
+        { drive_type_e::RA60, "RA60",   400176,   42, 60,  1, 0x22a4103c, 4,     1008,    true,      false },
+        { drive_type_e::RA70, "RA70",   547041,   33, 11,  1, 0x20643019, 18,    198,     false,     false },
+        { drive_type_e::RA81, "RA81",   891072,   51, 14,  1, 0x25641051, 5,     2856,    false,     false },
+        { drive_type_e::RA82, "RA82",   1216665,  57, 15,  1, 0x25641052, 11,    3420,    false,     false },
+        { drive_type_e::RA71, "RA71",   1367310,  51, 14,  1, 0x25641047, 40,    1428,    false,     false },
+        { drive_type_e::RA72, "RA72",   1953300,  51, 20,  1, 0x25641048, 37,    2040,    false,     false },
+        { drive_type_e::RA90, "RA90",   2376153,  69, 13,  1, 0x2564105a, 19,    1794,    false,     false },
+        { drive_type_e::RA92, "RA92",   2940951,  73, 13,  1, 0x2564105c, 29,    949,     false,     false },
+        { drive_type_e::RA73, "RA73",   3920490,  70, 21,  1, 0x25641049, 47,    198,     false,     false },
+        { drive_type_e::NONE, "", 0, 0, 0, 0, 0, 0, 0, false, false } };
 
     bool SetDriveType(const char* typeName);
     void UpdateCapacity(void);
     void UpdateMetadata(void);
-    DriveInfo _driveInfo;bool _online;
+    DriveInfo _driveInfo;
+    bool _online;
     uint32_t _unitDeviceNumber;
     uint16_t _unitClassModel;
     bool _useImageSize;

--- a/10.02_devices/2_src/mscp_server.cpp
+++ b/10.02_devices/2_src/mscp_server.cpp
@@ -629,12 +629,11 @@ mscp_server::GetUnitStatus(
     // This has nothing whatsoever to do with what's going on here but it makes me snicker
     // every time I read it so I'm including it.
     // Let's relay some information about our data-tesseract:
-    // Since our underlying storage is an image file on flash memory, we don't need to be concerned
-    // about seek times, so the below is appropriate:
+    // For older VMS, this has to match actual drive parameters.
     //
-    params->TrackSize = 1;  
-    params->GroupSize = 1;  
-    params->CylinderSize = 1; 
+    params->TrackSize = drive->GetSectsPerTrack();
+    params->GroupSize = drive->GetTracksPerGroup();
+    params->CylinderSize = drive->GetGroupsPerCylinder();
 
     params->RCTSize = drive->GetRCTSize();
     params->RBNs = drive->GetRBNs();


### PR DESCRIPTION
(Track,Group,Cylinder) = (1,1,1) causes some kind of overflow in older VMS (e.g. 5.5-2) on startup.

Instead, we use real drive values as gathered from DUSTAT (and as simh declares them).

Tested on a VAX 4000 Model 200 and an RA90 image of VMS 5.5-2. VMS was installed to an emulated SCSI drive attached to a CMD CQD-220A. The .img was copied from that emulator to the QBone, and run using a similar script to `vms73_rd54.sh` but with type and image parameters for uda0 changed.

Signed off on by @jdersch via IRC.