### PR TITLE
cpu20: support for "newer" instructions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.idea
+.CMakelists.txt
+cmake-build-debug
+CMakeLists.txt
+

--- a/10.02_devices/2_src/cpu.cpp
+++ b/10.02_devices/2_src/cpu.cpp
@@ -262,6 +262,7 @@ cpu_c::cpu_c() :
     register_count = 0;
     swab_vbit.value = false;
     extended_instr.value = false;
+    allow_mxps.value = false;
 
     memset(&bus, 0, sizeof(bus));
     memset(&ka11, 0, sizeof(ka11));
@@ -511,6 +512,7 @@ void cpu_c::worker(unsigned instance)
 
         ka11.swab_vbit = (swab_vbit.value == true);
         ka11.extended_instr = (extended_instr.value == true);
+        ka11.allow_mxps = (allow_mxps.value == true);
     }
 }
 

--- a/10.02_devices/2_src/cpu.cpp
+++ b/10.02_devices/2_src/cpu.cpp
@@ -261,6 +261,7 @@ cpu_c::cpu_c() :
     // must be qunibusdevice_c then!
     register_count = 0;
     swab_vbit.value = false;
+    extended_instr.value = false;
 
     memset(&bus, 0, sizeof(bus));
     memset(&ka11, 0, sizeof(ka11));
@@ -509,7 +510,7 @@ void cpu_c::worker(unsigned instance)
         }
 
         ka11.swab_vbit = (swab_vbit.value == true);
-
+        ka11.extended_instr = (extended_instr.value == true);
     }
 }
 

--- a/10.02_devices/2_src/cpu.hpp
+++ b/10.02_devices/2_src/cpu.hpp
@@ -150,7 +150,7 @@ public:
                                  false, "SWAB instruction does not(=0) or does(=1) modify psw v-bit (=0 is standard 11/20 behavior)");
 
     parameter_bool_c extended_instr = parameter_bool_c(this, "extended_inst", "exti",/*readonly*/
-                             false, "Enable extended instruction set (ASH, MUL, DIV etc) (=0 is standard 11/20 behavior)");
+                             false, "Enable extended instruction set (ASH, ASHC, MUL, DIV, XOR, SOB) (=0 is standard 11/20 behavior)");
 
     parameter_bool_c allow_mxps = parameter_bool_c(this, "allow_mxps", "mxps",/*readonly*/
                              false, "Allow mtps and mfps instructions (1=11/34, LSI11, 0=standard 11/20 behavior)");

--- a/10.02_devices/2_src/cpu.hpp
+++ b/10.02_devices/2_src/cpu.hpp
@@ -149,6 +149,9 @@ public:
     parameter_bool_c swab_vbit = parameter_bool_c(this, "swab_vbit", "swab",/*readonly*/
                                  false, "SWAB instruction does not(=0) or does(=1) modify psw v-bit (=0 is standard 11/20 behavior)");
 
+    parameter_bool_c extended_instr = parameter_bool_c(this, "extended_inst", "exti",/*readonly*/
+                             false, "Enable extended instruction set (ASH, MUL, DIV etc) (=0 is standard 11/20 behavior)");
+
     parameter_unsigned_c pc = parameter_unsigned_c(this, "PC", "pc",/*readonly*/
                               false, "", "%06o", "program counter helper register.", 16, 8);
 

--- a/10.02_devices/2_src/cpu.hpp
+++ b/10.02_devices/2_src/cpu.hpp
@@ -152,6 +152,9 @@ public:
     parameter_bool_c extended_instr = parameter_bool_c(this, "extended_inst", "exti",/*readonly*/
                              false, "Enable extended instruction set (ASH, MUL, DIV etc) (=0 is standard 11/20 behavior)");
 
+    parameter_bool_c allow_mxps = parameter_bool_c(this, "allow_mxps", "mxps",/*readonly*/
+                             false, "Allow mtps and mfps instructions (1=11/34, LSI11, 0=standard 11/20 behavior)");
+
     parameter_unsigned_c pc = parameter_unsigned_c(this, "PC", "pc",/*readonly*/
                               false, "", "%06o", "program counter helper register.", 16, 8);
 

--- a/10.02_devices/2_src/cpu20/11.h
+++ b/10.02_devices/2_src/cpu20/11.h
@@ -18,6 +18,7 @@ typedef uint32_t uint32;
 #define M16 0177777
 #define B7  0000200
 #define B15 0100000
+#define B31 0x80000000L
 #define nil NULL
 
 #define SETMASK(l, r, m) l = (((l)&~(m)) | ((r)&(m)))

--- a/10.02_devices/2_src/cpu20/ka11.c
+++ b/10.02_devices/2_src/cpu20/ka11.c
@@ -496,8 +496,7 @@ step(KA11 *cpu)
 				case 0072000:		TR(ASH);
                 	// ASH
 					RD_U;
-					CLC;
-					CLNZ;
+              		cpu->psw &= ~(PSW_N|PSW_Z);
 					b = cpu->r[reg];
 //					printf("ASH: reg=%d, in=%o, shift=%o\n", reg, b, DR);
 					word sh = (DR & 0x3f);				// Extract 6 bits
@@ -505,12 +504,14 @@ step(KA11 *cpu)
 						sh = 0x40 - sh;					// +ve shift, 1..62
                         if(sh > 15) {
                 			b = 0;
-                			CLC;
+//                			CLC;				// not clear whether this gets cleared
                 			SEZ;
                 		} else {
                 			mask = sgn(b) ? 0xffff : 0x0;
 							if(b & (1 << (sh - 1)))
 								SEC;
+							else
+								CLC;
 							b >>= sh;
 							mask <<= (16 - sh);
 							b |= mask;					// Sign extend
@@ -521,11 +522,13 @@ step(KA11 *cpu)
                 	} else {
 						if(sh > 15) {
 							b = 0;
-							CLC;
+//							CLC;
 							SEZ;
 						} else if(sh > 0) {
 							if(b & (1 << (16 - 1))) {	// Get bit shifted out & left
 								SEC;
+							} else {
+								CLC;
 							}
 							b <<= sh;
 							NZ;

--- a/10.02_devices/2_src/cpu20/ka11.c
+++ b/10.02_devices/2_src/cpu20/ka11.c
@@ -471,7 +471,6 @@ step(KA11 *cpu)
               			int32_t v1 = (int16_t) DR;
               			int32_t v2 = (int16_t) cpu->r[reg];
         	      		prod = v1 * v2;
-//    	          		printf("mul: r[%d]=%o (%d), dr=%o (%d), prod=%o (%d)\n", reg, v2, v2, v1, v1, prod, prod);
 						if(prod < -32768 || prod > 32767) {
 							SEC;
 						}
@@ -496,7 +495,7 @@ step(KA11 *cpu)
 					if(reg & 0x1) goto ri;			// for div register must be even
 					{
 						int32_t dv = (int16_t) DR;
-						prod = (uint32_t) cpu->r[reg + 1] | ((uint32_t) cpu->r[reg] << 16);	// 32bit signed r, r+1
+						prod = (uint32_t) cpu->r[reg + 1] | ((uint32_t) cpu->r[reg] << 16);
 						if(DR == 0) {
 							SEC;
 							SEV;
@@ -522,13 +521,12 @@ step(KA11 *cpu)
               		cpu->psw &= ~(PSW_N|PSW_Z|PSW_V);
 					b = cpu->r[reg];
 					sh = (DR & 0x3f);				// Extract 6 bits
-					if(sh & 0x20) {		// -ve?
+					if(sh & 0x20) {					// -ve?
 						// we shift right
 						sh = 0x40 - sh;					// +ve shift, 1..62
-//						printf("ASH: reg=%d, in=%o, shift=-%d (%o)\n", reg, b, sh, DR);
                			mask = sgn(b) ? 0xffff : 0x0;	// The previous sign gets shifted in
                         if(sh >= 17) {
-                        	//-- Really shifted out completely.
+                        	// Really shifted out completely.
                 			b = mask;
                 			if(mask)
                 				SEC;
@@ -549,8 +547,6 @@ step(KA11 *cpu)
 								SEN;
                 		}
                 	} else {
-//						printf("ASH: reg=%d, in=%o, shift=%d (%o)\n", reg, b, sh, DR);
-
                 		// we shift left
                 		if(sh == 0) {
                 			//-- Nothing -> only set Z and N flags
@@ -572,7 +568,6 @@ step(KA11 *cpu)
 								uint ob = b;
 								b <<= 1;
 								ob ^= b;
-//								printf("- sh=%d, b=%o, ob=%o, xor=%d\n", sh, b & 0xffff, ob & 0xffff, (ob & B15));
 								if(ob & B15) {					// Sign changed?
 									SEV;
 								}
@@ -581,7 +576,6 @@ step(KA11 *cpu)
 						}
                 	}
                 	b &= 0xffff;
-//					printf("ASH: out=%o, psw=%o\n", b, cpu->psw);
 					cpu->r[reg] = b;
 					SVC;
 
@@ -591,7 +585,6 @@ step(KA11 *cpu)
               		{
               			uint32_t val = ((uint32_t) cpu->r[reg] << 16) | cpu->r[reg | 1];	// The bitwise OR is intentional!
 
-//						printf("ASHC: reg=%d, in=%o, shift=%o\n", reg, val, DR);
 						sh = (DR & 0x3f);					// Extract 6 bits
 						if(sh & 0x20) {						// -ve?
 							// we shift right
@@ -618,7 +611,6 @@ step(KA11 *cpu)
 								uint32_t ob = val;
 								val <<= 1;
 								ob ^= val;
-//								printf("- sh=%d, b=%o, ob=%o, xor=%d\n", sh, b & 0xffff, ob & 0xffff, (ob & B15));
 								if(ob & B31) {					// Sign changed?
 									SEV;
 								}
@@ -628,7 +620,6 @@ step(KA11 *cpu)
 							if(val & B31)
 								SEN;
             	    	}
-//						printf("ASHC: out=%o\n", val);
 						if(reg & 0x1) {
 							cpu->r[reg] = (word) val;		// Truncated result
 						} else {
@@ -643,9 +634,7 @@ step(KA11 *cpu)
               		RD_U;
               		cpu->psw &= ~(PSW_N|PSW_Z|PSW_V);
 					b = cpu->r[reg];
-//					printf("XOR: reg=%d, in=%o, val=%o\n", (cpu->ir >> 6) & 07, b, DR);
 					b = DR ^ b;
-//					printf("- result=%o\n", b);
 					if(sgn(b)) {
 						SEN;
 					}
@@ -654,12 +643,10 @@ step(KA11 *cpu)
 
 				case 0077000:		TR(SOB);
 					b = --(cpu->r[reg]);		// decrement reg
-//					printf("SOB: reg=%d, val after dec=%o, off=%o\n", (cpu->ir >> 6) & 07, b, (cpu->ir & 077) << 1);
 					if(b != 0) {
 						//-- Jump
 						mask = (cpu->ir & 077) << 1;			// Get jump offset (*2)
 						cpu->r[7] -= mask;						// Decrement by offset
-//						printf("- jmp to %o\n", cpu->r[7]);
 					}
 					SVC;
 			}

--- a/10.02_devices/2_src/cpu20/ka11.c
+++ b/10.02_devices/2_src/cpu20/ka11.c
@@ -392,6 +392,13 @@ step(KA11 *cpu)
 		}	
 	}
 
+	if(cpu->r[7] == 01616) {
+	 	cpu->state = KA11_STATE_HALTED;
+	 	printf("\nUB BREAKPOINT\n");
+	 	printf("R0 %06o R1 %06o R2 %06o R3 %06o R4 %06o R5 %06o R6 %06o R7 %06o\n", cpu->r[0], cpu->r[1], cpu->r[2], cpu->r[3], cpu->r[4], cpu->r[5], cpu->r[6], cpu->r[7]);
+	 	printf("ba %06o ir %06o psw %06o\n", cpu->ba, cpu->ir, cpu->psw);
+	 	return;
+	}
 
 	oldpsw = PSW;
 	INA(PC, cpu->ir);
@@ -500,7 +507,7 @@ step(KA11 *cpu)
 					RD_U;
               		cpu->psw &= ~(PSW_N|PSW_Z);
 					b = cpu->r[reg];
-//					printf("ASH: reg=%d, in=%o, shift=%o\n", reg, b, DR);
+					printf("ASH: reg=%d, in=%o, shift=%o\n", reg, b, DR);
 					sh = (DR & 0x3f);				// Extract 6 bits
 					if(sh & 0x20) {		// -ve?
 						// we shift right
@@ -540,7 +547,7 @@ step(KA11 *cpu)
 								SEN;
 						}
                 	}
-//					printf("ASH: out=%o\n", b);
+					printf("ASH: out=%o, psw=%o\n", b, cpu->psw);
 					cpu->r[reg] = b;
 					SVC;
 
@@ -550,7 +557,7 @@ step(KA11 *cpu)
               		{
               			uint32_t val = ((uint32_t) cpu->r[reg] << 16) | cpu->r[reg | 1];	// The bitwise OR is intentional!
 
-//						printf("ASHC: reg=%d, in=%o, shift=%o\n", reg, val, DR);
+						printf("ASHC: reg=%d, in=%o, shift=%o\n", reg, val, DR);
 						sh = (DR & 0x3f);					// Extract 6 bits
 						if(sh & 0x20) {		// -ve?
 							// we shift right
@@ -592,7 +599,7 @@ step(KA11 *cpu)
 									SEN;
 							}
             	    	}
-//						printf("ASH: out=%o\n", b);
+						printf("ASH: out=%o\n", val);
 						if(reg & 0x1) {
 							cpu->r[reg] = (word) val;		// Truncated result
 						} else {
@@ -713,8 +720,11 @@ step(KA11 *cpu)
 		if(!cpu->allow_mxps || !by)
 			goto ri;
 		TR(MFPS);
-		RD_U;
+		by = 0;
+		if(addrop(cpu, dst, 0)) goto be;
+//		RD_U;
 		b = cpu->psw & 0377;
+		printf("mfps: res=%o\n", b);
 		WR; SVC;
 	}
 

--- a/10.02_devices/2_src/cpu20/ka11.c
+++ b/10.02_devices/2_src/cpu20/ka11.c
@@ -699,6 +699,7 @@ step(KA11 *cpu)
 		// mtps
 		if(!cpu->allow_mxps || !by)
 			goto ri;
+		TR(MTPS);
 		RD_U;
 		cpu->psw = (cpu->psw & 0xff00) | (DR & 0377);
 		SVC;
@@ -711,6 +712,8 @@ step(KA11 *cpu)
 		// mfps
 		if(!cpu->allow_mxps || !by)
 			goto ri;
+		TR(MFPS);
+		RD_U;
 		b = cpu->psw & 0377;
 		WR; SVC;
 	}

--- a/10.02_devices/2_src/cpu20/ka11.c
+++ b/10.02_devices/2_src/cpu20/ka11.c
@@ -507,11 +507,11 @@ step(KA11 *cpu)
 					RD_U;
               		cpu->psw &= ~(PSW_N|PSW_Z);
 					b = cpu->r[reg];
-					printf("ASH: reg=%d, in=%o, shift=%o\n", reg, b, DR);
 					sh = (DR & 0x3f);				// Extract 6 bits
 					if(sh & 0x20) {		// -ve?
 						// we shift right
 						sh = 0x40 - sh;					// +ve shift, 1..62
+						printf("ASH: reg=%d, in=%o, shift=-%d (%o)\n", reg, b, sh, DR);
                         if(sh > 15) {
                 			b = 0;
 //                			CLC;				// not clear whether this gets cleared
@@ -530,8 +530,10 @@ step(KA11 *cpu)
 								SEN;
                 		}
                 	} else {
+						printf("ASH: reg=%d, in=%o, shift=%d (%o)\n", reg, b, sh, DR);
+
                 		// we shift left
-						if(sh > 15) {
+						if(sh > 15 || b == 0) {
 							b = 0;
 //							CLC;
 							SEZ;
@@ -582,7 +584,7 @@ step(KA11 *cpu)
                 			}
 	                	} else {
     	            		//-- We shift left
-							if(sh > 31) {
+							if(sh > 31 || sh == 0) {
 								val = 0;
 //								CLC;
 								SEZ;

--- a/10.02_devices/2_src/cpu20/ka11.c
+++ b/10.02_devices/2_src/cpu20/ka11.c
@@ -392,13 +392,13 @@ step(KA11 *cpu)
 		}	
 	}
 
-	if(cpu->r[7] == 01616) {
-	 	cpu->state = KA11_STATE_HALTED;
-	 	printf("\nUB BREAKPOINT\n");
-	 	printf("R0 %06o R1 %06o R2 %06o R3 %06o R4 %06o R5 %06o R6 %06o R7 %06o\n", cpu->r[0], cpu->r[1], cpu->r[2], cpu->r[3], cpu->r[4], cpu->r[5], cpu->r[6], cpu->r[7]);
-	 	printf("ba %06o ir %06o psw %06o\n", cpu->ba, cpu->ir, cpu->psw);
-	 	return;
-	}
+//	if(cpu->r[7] == 016440) {
+//	 	cpu->state = KA11_STATE_HALTED;
+//	 	printf("\nUB BREAKPOINT\n");
+//	 	printf("R0 %06o R1 %06o R2 %06o R3 %06o R4 %06o R5 %06o R6 %06o R7 %06o\n", cpu->r[0], cpu->r[1], cpu->r[2], cpu->r[3], cpu->r[4], cpu->r[5], cpu->r[6], cpu->r[7]);
+//	 	printf("ba %06o ir %06o psw %06o\n", cpu->ba, cpu->ir, cpu->psw);
+//	 	return;
+//	}
 
 	oldpsw = PSW;
 	INA(PC, cpu->ir);
@@ -425,6 +425,8 @@ step(KA11 *cpu)
 	case 0120000: case 0020000:	TRB(CMP);
 		RD_B; CLCV;
 		b = SR + W(~DR) + 1; NC; BXT;
+		if(cpu->ir == 021527)
+			printf("cmp (r5),xx -> %o vs %o\n", SR, DR);
 		if(sgn((SR ^ DR) & ~(DR ^ b))) SEV;
 		NZ; SVC;
 	case 0130000: case 0030000:	TRB(BIT);
@@ -529,6 +531,7 @@ step(KA11 *cpu)
 							b >>= sh;
 							mask <<= (16 - sh);
 							b |= mask;					// Sign extend
+							b &= 0xffff;
 							NZ;
 							if(b & B15)
 								SEN;
@@ -554,8 +557,13 @@ step(KA11 *cpu)
 							}
 							uint ob = b;
 							b <<= sh;
-							if(sgn(b) != sgn(ob))
+							b &= 0xffff;
+
+							printf("--- b=%o, ob=%o, sgn(b)=%o, sgn(ob)=%o\n", b, ob, sgn(b), sgn(ob));
+							if(sgn(b) != sgn(ob)) {
+								printf("SEV\n");
 								SEV;
+							}
 							NZ;
 							if(b & B15)
 								SEN;

--- a/10.02_devices/2_src/cpu20/ka11.c
+++ b/10.02_devices/2_src/cpu20/ka11.c
@@ -446,30 +446,34 @@ step(KA11 *cpu)
 
 	case 0070000:
     	if(cpu->extended_instr) {
+    		printf("-- ext: %o\n", cpu->ir);
         	switch(cpu->ir & 0177000) {
               	default:
                 	goto ri;
 
 				case 0070000:
                 // MUL
+                break;
 
 				case 0071000:
                 // DIV
+                break;
 
 				case 0072000:		TR(ASH);
                 	// ASH
 					RD_U;
 					CLC;
 					CLNZ;
+					b = cpu->r[(cpu->ir >> 6) & 07];
+					printf("ASH: reg=%d, in=%o, shift=%o\n", (cpu->ir >> 6) & 07, b, DR);
 					if(sgn(DR)) {		// -ve?
         	        	int sh = (~DR + 1) & 0x3f;	// 1..63
-						b = cpu->r[(cpu->ir >> 8) & 07];
                         if(sh > 15) {
                 			b = 0;
                 			CLC;
                 			SEZ;
                 		} else {
-                			int mask = sgn(b) ? 0xffff : 0x0;
+                			mask = sgn(b) ? 0xffff : 0x0;
 							if(b & (1 << (sh - 1)))
 								SEC;
 							b >>= sh;
@@ -479,7 +483,6 @@ step(KA11 *cpu)
 							if(b & B15)
 								SEN;
                 		}
-						cpu->r[(cpu->ir >> 8) & 07] = b;
                 	} else {
 						int sh = (DR & 0x3f);
 						if(sh > 15) {
@@ -496,16 +499,20 @@ step(KA11 *cpu)
 								SEN;
 						}
                 	}
+					printf("ASH: out=%o\n", b);
+					cpu->r[(cpu->ir >> 6) & 07] = b;
 					SVC;
 
               	case 0073000:
                 	// ASHC
+                	break;
 
               	case 0074000:
                 	// XOR
-
+                	break;
 			}
 		}
+
         // All else, or not extended instr
        	goto ri;
 	}

--- a/10.02_devices/2_src/cpu20/ka11.c
+++ b/10.02_devices/2_src/cpu20/ka11.c
@@ -500,8 +500,9 @@ step(KA11 *cpu)
 					CLNZ;
 					b = cpu->r[reg];
 //					printf("ASH: reg=%d, in=%o, shift=%o\n", reg, b, DR);
-					if(sgn(DR)) {		// -ve?
-        	        	int sh = (~DR + 1) & 0x3f;	// 1..63
+					word sh = (DR & 0x3f);				// Extract 6 bits
+					if(sh & 0x20) {		// -ve?
+						sh = 0x40 - sh;					// +ve shift, 1..62
                         if(sh > 15) {
                 			b = 0;
                 			CLC;
@@ -518,7 +519,6 @@ step(KA11 *cpu)
 								SEN;
                 		}
                 	} else {
-						int sh = (DR & 0x3f);
 						if(sh > 15) {
 							b = 0;
 							CLC;

--- a/10.02_devices/2_src/cpu20/ka11.c
+++ b/10.02_devices/2_src/cpu20/ka11.c
@@ -494,18 +494,20 @@ step(KA11 *cpu)
 					RD_U;
               		cpu->psw &= ~(PSW_N|PSW_Z|PSW_V|PSW_C);
 					if(reg & 0x1) goto ri;			// for div register must be even
-					prod = (int32_t) cpu->r[reg] | ((int32_t) cpu->r[reg + 1] << 16);	// 32bit signed r, r+1
-					if(DR == 0) {
-						SEC;
-						SEV;
-					} else {
-						uint32_t quot = prod / (int32_t) DR;
-						uint32_t rem = prod % (int32_t) DR;
-						if(quot < 32768 || quot > 32767) {
+					{
+						prod = (uint32_t) cpu->r[reg] | ((uint32_t) cpu->r[reg + 1] << 16);	// 32bit signed r, r+1
+						if(DR == 0) {
+							SEC;
 							SEV;
 						} else {
-							cpu->r[reg] = (word) quot;
-							cpu->r[reg + 1] = (word) (rem);
+							int32_t quot = prod / (int32_t) DR;
+							int32_t rem = prod % (int32_t) DR;
+							if(quot < -32768 || quot > 32767) {
+								SEV;
+							} else {
+								cpu->r[reg] = (word) quot;
+								cpu->r[reg + 1] = (word) (rem);
+							}
 						}
 					}
 					SVC;

--- a/10.02_devices/2_src/cpu20/ka11.c
+++ b/10.02_devices/2_src/cpu20/ka11.c
@@ -507,9 +507,18 @@ step(KA11 *cpu)
                 	// ASHC
                 	break;
 
-              	case 0074000:
-                	// XOR
-                	break;
+              	case 0074000:		TR(XOR);
+              		RD_U;
+              		cpu->psw &= ~(PSW_N|PSW_Z|PSW_V);
+					b = cpu->r[(cpu->ir >> 6) & 07];
+					printf("XOR: reg=%d, in=%o, val=%o\n", (cpu->ir >> 6) & 07, b, DR);
+					b = DR ^ b;
+					printf("- result=%o\n", b);
+					if(sgn(b)) {
+						SEN;
+					}
+					NZ;
+					WR; SVC;
 			}
 		}
 

--- a/10.02_devices/2_src/cpu20/ka11.c
+++ b/10.02_devices/2_src/cpu20/ka11.c
@@ -632,6 +632,7 @@ step(KA11 *cpu)
         // All else, or not extended instr
        	goto ri;
 	}
+	//-- remaining here is ir=x0xxxx
 
 	/* Unary */
 	switch(cpu->ir & 0007700){
@@ -695,11 +696,23 @@ step(KA11 *cpu)
 		WR; SVC;
 
 	case 0006400:
+		// mtps
+		if(!cpu->allow_mxps || !by)
+			goto ri;
+		RD_U;
+		cpu->psw = (cpu->psw & 0xff00) | (DR & 0377);
+		SVC;
+
 	case 0006500:
 	case 0006600:
-	case 0006700:
 		goto ri;
 
+	case 0006700:
+		// mfps
+		if(!cpu->allow_mxps || !by)
+			goto ri;
+		b = cpu->psw & 0377;
+		WR; SVC;
 	}
 
 	switch(cpu->ir & 0107400){

--- a/10.02_devices/2_src/cpu20/ka11.h
+++ b/10.02_devices/2_src/cpu20/ka11.h
@@ -35,6 +35,7 @@ struct KA11
 
     // jal extended instruction set
     int extended_instr;
+    int allow_mxps;
 };
 
 

--- a/10.02_devices/2_src/cpu20/ka11.h
+++ b/10.02_devices/2_src/cpu20/ka11.h
@@ -32,6 +32,9 @@ struct KA11
 
 	word sw;
 	int swab_vbit;
+
+    // jal extended instruction set
+    int extended_instr;
 };
 
 


### PR DESCRIPTION
I don't know whether this will be useful, but at least it is here ;)
# What it does

This code implements the following instructions:

- ash
- ashc
- mul
- div
- xor
- sob
- mfps
- mtps

They are not enabled by default. I added two extra cpu20 parameters:
- extended_inst which enables ast till sob
- enable_mxps which enables mfps and mtps

Ideally one would probably rather implement a whole new CPU class (for instance CPU34) but looking at the code I found that a bit too daunting, and it would probably duplicate a lot of code or become slower, so I chose the parameters approach.

I used the FKACA0 XXDP test to test the instructions and this now passes without problems. This tests the instructions ash, ashc, mul and div but not the others, although since mfps and mtps are actually used a lot in those tests one might assume that these work too with the tests passing. It leaves the xor and sob instructions untested.

# Why?

I wanted to test a DELUA card using the Unibone as a test platform. The related test died immediately with an illegal instruction trap. I decided to fix that by implementing the missing instructions.
