### PR TITLE
Shebang

### DIFF
--- a/10.03_app_demo/2_src/application.cpp
+++ b/10.03_app_demo/2_src/application.cpp
@@ -234,20 +234,23 @@ void application_c::parse_commandline(int argc, char **argv)
                     commandline_option_error((char *)"4 LEDs can only display values 0..15");
                 gpios->cmdline_leds = n ;
             }
-        } else if (getopt_parser.isoption("test")) {
-            int i1, i2;
-            std::string s;
-            if (getopt_parser.arg_i("iarg1", &i1) < 0)
+        // } else if (getopt_parser.isoption("test")) {
+        //     int i1, i2;
+        //     std::string s;
+        //     if (getopt_parser.arg_i("iarg1", &i1) < 0)
+        //         commandline_option_error(NULL);
+        //     if (getopt_parser.arg_i("iarg2", &i2) < 0)
+        //         commandline_option_error(NULL);
+        //     std::cout << "iarg1=" << i1 << ", iarg2=" << i2;
+        //     if (getopt_parser.arg_s("soptarg", s))
+        //         std::cout << ", soptarg=" << s;
+        //     std::cout << "\n";
+        } else if(getopt_parser.isoption("")) {                 // Non-option?
+            if (getopt_parser.arg_s("cmdfile", opt_cmdfilename) < 0) {
                 commandline_option_error(NULL);
-            if (getopt_parser.arg_i("iarg2", &i2) < 0)
-                commandline_option_error(NULL);
-            std::cout << "iarg1=" << i1 << ", iarg2=" << i2;
-            if (getopt_parser.arg_s("soptarg", s))
-                std::cout << ", soptarg=" << s;
-            std::cout << "\n";
-        } else if(getopt_parser.isoption("")) {
-            if (getopt_parser.arg_s("cmdfile", opt_cmdfilename) < 0)
-                commandline_option_error(NULL);
+            } else {
+                opt_changedir = true;
+            }
         }
         res = getopt_parser.next();
     }
@@ -331,6 +334,19 @@ int application_c::run(int argc, char *argv[])
                                  opt_cmdfilename.c_str()));
             return -1;
         }
+
+        if(opt_changedir) {
+            // Make the cwd the dir where the command file resides
+            // Needs to come after opening the cmdfile because the
+            // cmd will cause the open to fail (as the relative path)
+            // changes)
+            int pos = opt_cmdfilename.find_last_of('/');
+            if(pos > 0) {
+                std::string wd = opt_cmdfilename.substr(0, pos);
+                chdir(wd.c_str());
+            }
+        }
+
     }
 
     std::cout << version << "\n";

--- a/10.03_app_demo/2_src/application.cpp
+++ b/10.03_app_demo/2_src/application.cpp
@@ -184,13 +184,17 @@ void application_c::parse_commandline(int argc, char **argv)
                          "\"debug\": LEDs not used, free for internal debugging.", "",
                          "", "", "");
 
+    
 	// test options
 
-    getopt_parser.define("t", "test", "iarg1,iarg2", "soptarg", "8 15",
-                         "Tests the new c++ getop2.cpp\n"
-                         "Multiline info, fix and optional args, short and long examples", "1,2",
-                         "simple sets both mandatory int args", "1 2 hello",
-                         "Sets integer args and option string arg");
+    // getopt_parser.define("t", "test", "iarg1,iarg2", "soptarg", "8 15",
+    //                      "Tests the new c++ getop2.cpp\n"
+    //                      "Multiline info, fix and optional args, short and long examples", "1,2",
+    //                      "simple sets both mandatory int args", "1 2 hello",
+    //                      "Sets integer args and option string arg");
+
+    getopt_parser.define("", "", "cmdfile", "", "", "File with statements", "Lines", "testseq", "", "");
+
 //	if (argc < 2)
 //		help(); // at least 1 required
     logger->default_level = LL_WARNING;
@@ -241,6 +245,9 @@ void application_c::parse_commandline(int argc, char **argv)
             if (getopt_parser.arg_s("soptarg", s))
                 std::cout << ", soptarg=" << s;
             std::cout << "\n";
+        } else if(getopt_parser.isoption("")) {
+            if (getopt_parser.arg_s("cmdfile", opt_cmdfilename) < 0)
+                commandline_option_error(NULL);
         }
         res = getopt_parser.next();
     }

--- a/10.03_app_demo/2_src/application.hpp
+++ b/10.03_app_demo/2_src/application.hpp
@@ -62,6 +62,7 @@ public:
 	// command line args
 	unsigned opt_linewidth = 80;
 	std::string opt_cmdfilename;
+	bool opt_changedir = false;
 	getopt_c getopt_parser;
 	void help(void);
 	void commandline_error(void);


### PR DESCRIPTION
This allows the "demo" application to accept the "cmdfile" as a parameter without the --cmdfile option. This, in turn, makes it possible to use the "demo" command as a "shebang" in Unibone scripts which means that instead of the pair of [xxx.sh, xxx.cmd] files for each configuration we can have a single executable .sh file:

example.sh:
```
#!/root/10.03_app_demo/4_deploy/demo
dc                      # "device + cpu" test menu

# Make a serial port.
sd dl11
en dl11                 # use emulated serial console
p p ttyS2               # use "UART2 connector, see FAQ
en kw11                 # enable KW11 on DL11-W

pwr
.wait 3000              # wait for PDP-11 to reset
m i                     # install max UNIBUS memory

# Deposit bootloader into memory
m ll dy.lst		# RX02 boot loader
en ry                   # enable RX11 controller
en rybox

sd rybox
p pwr 1                 # power-on drive box

sd ry0
p it0 1 # track 0 in image
p img 11XX_5.RX2  	# insert floppy into drive #0
p emulation_speed 10    # 10x speed. Load disk in 5 seconds

.print Disk drive now on track after 5 secs
.wait   5000            # wait until drive spins up
p                       # show all params of RL1

en cpu20
sd cpu20

init
# Set pc to 10000, the address of the dy.lst boot loader.
p pc 10000

.print Start from 0 or 10000 to boot from drive 0, 10010 for drive 1, ...
.print PC is set to 10000 now
.print Reload with "m ll"
.print Start the CPU by entering "p s 1"
```

## Implementation notes

The code adds a non-option parameter which will be the file name of the file containing the Unibone commands. When the demo application is used as a shebang in a script Linux will start the demo executable and add the name of the script containing the shebang as its only parameter.
This parameter is now recognized as an alternative to the --cmdfile [filename] option.

There is one other change related to this. When used in this way the code changes the current directory to the directory in which the script resides. In this way all file resources used by a script will by default be located in that same directory, and even if the script is used with a long start path, i.e. /home/10.03/applications/example.sh the files will still be found.

I had to remove the "test" option from the code. For some reason this option would always trigger for a non-option argument. It does not seem to do anything, and there seems to be a bug around parsing it.

